### PR TITLE
feat: add Zed as primary editor, replacing VS Code

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -35,7 +35,8 @@ brew "gh-dash"          # GitHub CLI dashboard extension
 cask "iterm2"
 cask "brave-browser"
 cask "google-chrome"
-cask "visual-studio-code"
+# cask "visual-studio-code"  # Replaced by Zed
+cask "zed"
 cask "slack"
 cask "spotify"
 cask "postman"
@@ -47,4 +48,4 @@ cask "font-fira-code-nerd-font" # Nerd font for icons (eza/starship)
 
 # Catppuccin Theme Tools
 brew "starship"         # Prompt theming (already listed above)
-# VS Code extension: Catppuccin for VSCode (install via marketplace)
+# Zed extension: Catppuccin (auto-installs via zed/settings.json auto_install_extensions)

--- a/Brewfile
+++ b/Brewfile
@@ -35,7 +35,6 @@ brew "gh-dash"          # GitHub CLI dashboard extension
 cask "iterm2"
 cask "brave-browser"
 cask "google-chrome"
-# cask "visual-studio-code"  # Replaced by Zed
 cask "zed"
 cask "slack"
 cask "spotify"
@@ -48,4 +47,3 @@ cask "font-fira-code-nerd-font" # Nerd font for icons (eza/starship)
 
 # Catppuccin Theme Tools
 brew "starship"         # Prompt theming (already listed above)
-# Zed extension: Catppuccin (auto-installs via zed/settings.json auto_install_extensions)

--- a/Brewfile
+++ b/Brewfile
@@ -44,6 +44,3 @@ cask "signal"
 cask "docker"
 cask "raycast"          # Productivity launcher
 cask "font-fira-code-nerd-font" # Nerd font for icons (eza/starship)
-
-# Catppuccin Theme Tools
-brew "starship"         # Prompt theming (already listed above)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The repository is organized into **topics**, making it easy to modularize your c
 - `macos/`: macOS system defaults and UI/UX settings.
 - `system/`: Global environment variables, paths, and generic aliases.
 - `vim/`: Vim configuration.
+- `zed/`: Zed editor settings and keybindings (symlinked to `~/.config/zed/`).
 - `zsh/`: Zsh configuration, plugins, and modular initialization.
 
 ## Features
@@ -28,3 +29,29 @@ The repository is organized into **topics**, making it easy to modularize your c
 - **Auto-update**: Automatically checks for updates to your dotfiles once a day.
 - **Mise integration**: Blazing fast management for Node, Ruby, Python, and more.
 - **Advanced Git**: Includes `gh-dash` and powerful log visualization.
+- **Zed editor**: Primary editor with Catppuccin theme, Fira Code font, Prettier formatting, and custom keybindings — all managed as dotfiles.
+
+## Zed Editor
+
+[Zed](https://zed.dev) is configured as the primary editor. Config files live in `zed/` and are symlinked to `~/.config/zed/` by `bootstrap.sh`.
+
+| File | Destination | Purpose |
+|------|-------------|---------|
+| `zed/settings.json` | `~/.config/zed/settings.json` | Editor settings, theme, formatting |
+| `zed/keymap.json` | `~/.config/zed/keymap.json` | Custom keybindings |
+
+**Key settings:**
+- **Theme**: Catppuccin Mocha (dark) / Catppuccin Latte (light), follows system appearance
+- **Font**: Fira Code 13px with ligatures
+- **Formatting**: Prettier on save for JS/TS/TSX/JSON/HTML/Markdown
+- **Extensions**: Auto-installed on first launch (Catppuccin, Prettier, ESLint, Dockerfile, etc.)
+- **Telemetry**: Disabled
+
+**Keybindings (ported from VS Code):**
+
+| Shortcut | Action |
+|----------|--------|
+| `cmd+]` / `cmd+[` | Next / previous terminal pane |
+| `cmd+d` | New terminal |
+| `cmd+w` | Close active item |
+| `cmd+k cmd+z` | Toggle centered layout (zen mode) |

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -39,6 +39,11 @@ ln -sf "$DOTFILES_ROOT/system/.curlrc" "$HOME/.curlrc"
 # Vim
 ln -sf "$DOTFILES_ROOT/vim/.vimrc" "$HOME/.vimrc"
 
+# Zed
+mkdir -p "$HOME/.config/zed"
+ln -sf "$DOTFILES_ROOT/zed/settings.json" "$HOME/.config/zed/settings.json"
+ln -sf "$DOTFILES_ROOT/zed/keymap.json" "$HOME/.config/zed/keymap.json"
+
 # 4. Install Catppuccin theme
 if [ -f "$DOTFILES_ROOT/theme/install.sh" ]; then
   echo "Installing Catppuccin theme..."

--- a/theme/install.sh
+++ b/theme/install.sh
@@ -25,9 +25,6 @@ if [[ -d "$HOME/Library/Application Support/iTerm2/DynamicProfiles" ]]; then
   ln -sf "$DOTFILES/theme/iterm2-catppuccin.json" "$HOME/Library/Application Support/iTerm2/DynamicProfiles/catppuccin.json"
 fi
 
-# Zed theme - auto-installed via settings
-echo "→ Zed: Catppuccin theme auto-installs via auto_install_extensions in zed/settings.json"
-
 # Vim setup
 echo "→ Setting up Vim Catppuccin..."
 mkdir -p "$HOME/.vim/pack/catppuccin/start"
@@ -40,6 +37,5 @@ fi
 echo "✅ Catppuccin theme installed!"
 echo ""
 echo "Manual steps:"
-echo "  1. Open Zed - Catppuccin theme installs automatically"
-echo "  2. In iTerm2: Preferences → Profiles → Colors → Color Presets → Catppuccin Mocha"
-echo "  3. Restart your terminal"
+echo "  1. In iTerm2: Preferences → Profiles → Colors → Color Presets → Catppuccin Mocha"
+echo "  2. Restart your terminal"

--- a/theme/install.sh
+++ b/theme/install.sh
@@ -25,9 +25,8 @@ if [[ -d "$HOME/Library/Application Support/iTerm2/DynamicProfiles" ]]; then
   ln -sf "$DOTFILES/theme/iterm2-catppuccin.json" "$HOME/Library/Application Support/iTerm2/DynamicProfiles/catppuccin.json"
 fi
 
-# VS Code settings - manual note
-echo "→ VS Code: Install 'Catppuccin for VSCode' extension from marketplace"
-echo "  Then set theme to 'Catppuccin Mocha' in settings"
+# Zed theme - auto-installed via settings
+echo "→ Zed: Catppuccin theme auto-installs via auto_install_extensions in zed/settings.json"
 
 # Vim setup
 echo "→ Setting up Vim Catppuccin..."
@@ -41,6 +40,6 @@ fi
 echo "✅ Catppuccin theme installed!"
 echo ""
 echo "Manual steps:"
-echo "  1. Install VS Code extension: 'Catppuccin for VSCode'"
+echo "  1. Open Zed - Catppuccin theme installs automatically"
 echo "  2. In iTerm2: Preferences → Profiles → Colors → Color Presets → Catppuccin Mocha"
 echo "  3. Restart your terminal"

--- a/zed/keymap.json
+++ b/zed/keymap.json
@@ -1,6 +1,4 @@
-// ~/.config/zed/keymap.json
 [
-  // Terminal: navigate panes with cmd+] / cmd+[
   {
     "context": "Terminal",
     "bindings": {
@@ -8,7 +6,6 @@
       "cmd-[": "terminal_panel::MoveTerminalLeft"
     }
   },
-  // Terminal: split / close
   {
     "context": "Terminal",
     "bindings": {
@@ -16,7 +13,6 @@
       "cmd-w": "pane::CloseActiveItem"
     }
   },
-  // Zen mode toggle
   {
     "context": "Workspace",
     "bindings": {

--- a/zed/keymap.json
+++ b/zed/keymap.json
@@ -1,0 +1,26 @@
+// ~/.config/zed/keymap.json
+[
+  // Terminal: navigate panes with cmd+] / cmd+[
+  {
+    "context": "Terminal",
+    "bindings": {
+      "cmd-]": "terminal_panel::MoveTerminalRight",
+      "cmd-[": "terminal_panel::MoveTerminalLeft"
+    }
+  },
+  // Terminal: split / close
+  {
+    "context": "Terminal",
+    "bindings": {
+      "cmd-d": "workspace::NewTerminal",
+      "cmd-w": "pane::CloseActiveItem"
+    }
+  },
+  // Zen mode toggle
+  {
+    "context": "Workspace",
+    "bindings": {
+      "cmd-k cmd-z": "workspace::ToggleCenteredLayout"
+    }
+  }
+]

--- a/zed/settings.json
+++ b/zed/settings.json
@@ -1,0 +1,173 @@
+// ~/.config/zed/settings.json
+{
+  // === Appearance ===
+  "theme": {
+    "mode": "system",
+    "dark": "Catppuccin Mocha",
+    "light": "Catppuccin Latte"
+  },
+  "buffer_font_family": "Fira Code",
+  "buffer_font_size": 13,
+  "buffer_font_features": {
+    "calt": true
+  },
+  "ui_font_family": "Fira Code",
+  "ui_font_size": 14,
+
+  // === Editor Behavior ===
+  "tab_size": 2,
+  "hard_tabs": false,
+  "word_wrap": "none",
+  "show_whitespaces": "all",
+  "scrollbar": {
+    "show": "never"
+  },
+  "minimap": {
+    "enabled": false
+  },
+  "scroll_beyond_last_line": "one_page",
+  "autosave": "off",
+  "format_on_save": "on",
+  "auto_indent": "none",
+  "ensure_final_newline_on_save": true,
+  "remove_trailing_whitespace_on_save": true,
+  "restore_on_startup": "last_session",
+
+  // === Bracket / Pairs ===
+  "indent_guides": {
+    "enabled": true,
+    "coloring": "indent_aware"
+  },
+  "auto_close_brackets": "always",
+
+  // === Git ===
+  "git": {
+    "enabled": true,
+    "git_gutter": "tracked_files",
+    "inline_blame": {
+      "enabled": true,
+      "delay_ms": 600
+    }
+  },
+
+  // === Telemetry ===
+  "telemetry": {
+    "diagnostics": false,
+    "metrics": false
+  },
+
+  // === Terminal ===
+  "terminal": {
+    "font_family": "Fira Code",
+    "font_size": 13,
+    "cursor_shape": "bar",
+    "blinking": "on"
+  },
+
+  // === Language-Specific ===
+  "languages": {
+    "JavaScript": {
+      "tab_size": 2,
+      "format_on_save": "on",
+      "formatter": {
+        "external": {
+          "command": "prettier",
+          "arguments": ["--stdin-filepath", "{buffer_path}"]
+        }
+      }
+    },
+    "TypeScript": {
+      "tab_size": 2,
+      "format_on_save": "on",
+      "formatter": {
+        "external": {
+          "command": "prettier",
+          "arguments": ["--stdin-filepath", "{buffer_path}"]
+        }
+      }
+    },
+    "TSX": {
+      "tab_size": 2,
+      "format_on_save": "on",
+      "formatter": {
+        "external": {
+          "command": "prettier",
+          "arguments": ["--stdin-filepath", "{buffer_path}"]
+        }
+      }
+    },
+    "JSON": {
+      "tab_size": 2,
+      "format_on_save": "on",
+      "formatter": {
+        "external": {
+          "command": "prettier",
+          "arguments": ["--stdin-filepath", "{buffer_path}"]
+        }
+      }
+    },
+    "HTML": {
+      "tab_size": 2,
+      "format_on_save": "on",
+      "formatter": {
+        "external": {
+          "command": "prettier",
+          "arguments": ["--stdin-filepath", "{buffer_path}"]
+        }
+      }
+    },
+    "Markdown": {
+      "tab_size": 2,
+      "format_on_save": "on",
+      "formatter": {
+        "external": {
+          "command": "prettier",
+          "arguments": ["--stdin-filepath", "{buffer_path}"]
+        }
+      }
+    },
+    "YAML": {
+      "tab_size": 2
+    },
+    "Dockerfile": {
+      "tab_size": 2
+    }
+  },
+
+  // === Extensions ===
+  "auto_install_extensions": {
+    "catppuccin": true,
+    "prettier": true,
+    "eslint": true,
+    "dockerfile": true,
+    "docker-compose": true,
+    "html": true,
+    "toml": true,
+    "env": true
+  },
+
+  // === AI / Agent ===
+  "features": {
+    "edit_prediction_provider": "none"
+  },
+
+  // === Search ===
+  "search": {
+    "line_numbers_in_results": true
+  },
+
+  // === Project Panel ===
+  "project_panel": {
+    "dock": "left",
+    "file_icons": true,
+    "folder_icons": true,
+    "git_status": true,
+    "indent_size": 20,
+    "auto_reveal_entries": true
+  },
+
+  // === Collaboration ===
+  "collaboration_panel": {
+    "dock": "left"
+  }
+}

--- a/zed/settings.json
+++ b/zed/settings.json
@@ -1,6 +1,4 @@
-// ~/.config/zed/settings.json
 {
-  // === Appearance ===
   "theme": {
     "mode": "system",
     "dark": "Catppuccin Mocha",
@@ -13,8 +11,6 @@
   },
   "ui_font_family": "Fira Code",
   "ui_font_size": 14,
-
-  // === Editor Behavior ===
   "tab_size": 2,
   "hard_tabs": false,
   "word_wrap": "none",
@@ -32,15 +28,11 @@
   "ensure_final_newline_on_save": true,
   "remove_trailing_whitespace_on_save": true,
   "restore_on_startup": "last_session",
-
-  // === Bracket / Pairs ===
   "indent_guides": {
     "enabled": true,
     "coloring": "indent_aware"
   },
   "auto_close_brackets": "always",
-
-  // === Git ===
   "git": {
     "enabled": true,
     "git_gutter": "tracked_files",
@@ -49,22 +41,16 @@
       "delay_ms": 600
     }
   },
-
-  // === Telemetry ===
   "telemetry": {
     "diagnostics": false,
     "metrics": false
   },
-
-  // === Terminal ===
   "terminal": {
     "font_family": "Fira Code",
     "font_size": 13,
     "cursor_shape": "bar",
     "blinking": "on"
   },
-
-  // === Language-Specific ===
   "languages": {
     "JavaScript": {
       "tab_size": 2,
@@ -133,8 +119,6 @@
       "tab_size": 2
     }
   },
-
-  // === Extensions ===
   "auto_install_extensions": {
     "catppuccin": true,
     "prettier": true,
@@ -145,18 +129,12 @@
     "toml": true,
     "env": true
   },
-
-  // === AI / Agent ===
   "features": {
     "edit_prediction_provider": "none"
   },
-
-  // === Search ===
   "search": {
     "line_numbers_in_results": true
   },
-
-  // === Project Panel ===
   "project_panel": {
     "dock": "left",
     "file_icons": true,
@@ -165,8 +143,6 @@
     "indent_size": 20,
     "auto_reveal_entries": true
   },
-
-  // === Collaboration ===
   "collaboration_panel": {
     "dock": "left"
   }


### PR DESCRIPTION
## Summary

Replaces VS Code with [Zed](https://zed.dev) as the primary editor. All existing VS Code customizations have been ported to Zed's native config format.

---

## Changes

### `Brewfile`
- Removed `cask "visual-studio-code"` (kept as a comment for reference)
- Added `cask "zed"`
- Updated Catppuccin comment to reference Zed's auto-install mechanism instead of the VS Code marketplace

### `zed/settings.json` _(new)_
Symlinked to `~/.config/zed/settings.json`. Ports all VS Code customizations:

| Setting | Value |
|---------|-------|
| Theme | Catppuccin Mocha (dark) / Catppuccin Latte (light), follows system |
| Font | Fira Code 13px, ligatures enabled (`calt: true`) |
| Tab size | 2 spaces, no hard tabs |
| Word wrap | Off |
| Whitespace | Show all |
| Minimap | Disabled |
| Format on save | On (Prettier via external formatter for JS/TS/TSX/JSON/HTML/Markdown) |
| Trailing whitespace | Removed on save |
| Final newline | Ensured on save |
| Telemetry | Fully disabled (diagnostics + metrics) |
| Git gutter | Enabled on tracked files |
| Inline blame | Enabled with 600ms delay |

Extensions auto-install on first launch: `catppuccin`, `prettier`, `eslint`, `dockerfile`, `docker-compose`, `html`, `toml`, `env`.

### `zed/keymap.json` _(new)_
Symlinked to `~/.config/zed/keymap.json`. Ports VS Code keybindings:

| Shortcut | Action |
|----------|--------|
| `cmd+]` / `cmd+[` | Navigate terminal panes right/left |
| `cmd+d` | Open new terminal |
| `cmd+w` | Close active item |
| `cmd+k cmd+z` | Toggle centered layout (Zed's zen mode equivalent) |

### `bootstrap.sh`
Added symlink block for Zed config after the Vim block:

```bash
# Zed
mkdir -p "$HOME/.config/zed"
ln -sf "$DOTFILES_ROOT/zed/settings.json" "$HOME/.config/zed/settings.json"
ln -sf "$DOTFILES_ROOT/zed/keymap.json" "$HOME/.config/zed/keymap.json"
```

### `theme/install.sh`
- Replaced the VS Code manual install echo with a note that Zed's Catppuccin theme auto-installs via `auto_install_extensions`
- Updated the manual steps list accordingly

### `README.md`
- Added `zed/` to the Structure section
- Added a new **Zed Editor** section documenting the config files, key settings, and keybindings table