### PR TITLE
feat: improve dotfiles for Codex-first AI workflow

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -33,6 +33,7 @@ brew "gh-dash"          # GitHub CLI dashboard extension
 
 # Casks (Apps)
 cask "ghostty"           # GPU-accelerated terminal (replaces iTerm2)
+cask "codex"             # OpenAI Codex CLI
 cask "brave-browser"
 cask "google-chrome"
 cask "zed"

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ The repository is organized into **topics**, making it easy to modularize your c
 **Install Codex CLI:**
 
 ```bash
+# macOS (preferred in this repo)
+brew install --cask codex
+
+# cross-platform alternative
 npm i -g @openai/codex
 ```
 
@@ -94,7 +98,7 @@ npm i -g @openai/codex
 - `cxe` → `codex exec`
 - `cxr` → `codex resume --last`
 - `cxreview` → start Codex with `/review`
-- `cxup` → upgrade Codex CLI
+- `cxup` → upgrade Codex CLI (uses Homebrew cask when Codex was installed with brew; otherwise npm)
 
 > Security note: This setup intentionally avoids `danger-full-access` / `--yolo` defaults.
 

--- a/README.md
+++ b/README.md
@@ -74,11 +74,8 @@ The repository is organized into **topics**, making it easy to modularize your c
 **Install Codex CLI:**
 
 ```bash
-# macOS (preferred in this repo)
 brew install --cask codex
-
-# cross-platform alternative
-npm i -g @openai/codex
+npm i -g @openai/codex  # cross-platform alternative
 ```
 
 **Key defaults in this repo:**

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The repository is organized into **topics**, making it easy to modularize your c
 - `vim/`: Vim configuration.
 - `ghostty/`: Ghostty terminal configuration (symlinked to `~/.config/ghostty/`).
 - `zed/`: Zed editor settings and keybindings (symlinked to `~/.config/zed/`).
+- `codex/`: Codex CLI configuration (symlinked to `~/.codex/`).
 - `zsh/`: Zsh configuration, plugins, and modular initialization.
 
 ## Features
@@ -32,6 +33,7 @@ The repository is organized into **topics**, making it easy to modularize your c
 - **Advanced Git**: Includes `gh-dash` and powerful log visualization.
 - **Ghostty terminal**: GPU-accelerated terminal with Catppuccin theme, Fira Code font, and custom keybindings — fully configured as dotfiles.
 - **Zed editor**: Primary editor with Catppuccin theme, Fira Code font, Prettier formatting, and custom keybindings — all managed as dotfiles.
+- **Codex CLI workflow**: Safe-by-default Codex config, shell shortcuts, and completion for day-to-day AI coding.
 
 ## Ghostty Terminal
 
@@ -60,6 +62,41 @@ The repository is organized into **topics**, making it easy to modularize your c
 | `cmd+0` | Reset font size |
 
 > **Note:** `theme/iterm2-catppuccin.json` is preserved in the repo for historical reference but is no longer used.
+
+## Codex CLI Workflow
+
+[Codex CLI](https://developers.openai.com/codex/cli/) is configured for a secure, fast terminal-first AI coding flow.
+
+| File | Destination | Purpose |
+|------|-------------|---------|
+| `codex/config.toml` | `~/.codex/config.toml` | Default model, approvals/sandbox, search mode, feature toggles |
+
+**Install Codex CLI:**
+
+```bash
+npm i -g @openai/codex
+```
+
+**Key defaults in this repo:**
+- `model = "gpt-5.3-codex"`
+- `approval_policy = "on-request"`
+- `sandbox_mode = "workspace-write"`
+- `web_search = "cached"` (safer default than live web)
+- `/review` uses `review_model = "gpt-5.3-codex"`
+
+**Enabled quality-of-life features:**
+- `shell_snapshot` (faster repeated command runs)
+- `unified_exec` (improved command execution path)
+- `undo` (safer edit iteration)
+
+**Zsh shortcuts:**
+- `cx` → `codex`
+- `cxe` → `codex exec`
+- `cxr` → `codex resume --last`
+- `cxreview` → start Codex with `/review`
+- `cxup` → upgrade Codex CLI
+
+> Security note: This setup intentionally avoids `danger-full-access` / `--yolo` defaults.
 
 ## Zed Editor
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -48,6 +48,10 @@ ln -sf "$DOTFILES_ROOT/zed/keymap.json" "$HOME/.config/zed/keymap.json"
 mkdir -p "$HOME/.config/ghostty"
 ln -sf "$DOTFILES_ROOT/ghostty/config" "$HOME/.config/ghostty/config"
 
+# Codex CLI
+mkdir -p "$HOME/.codex"
+ln -sf "$DOTFILES_ROOT/codex/config.toml" "$HOME/.codex/config.toml"
+
 # 4. Install Catppuccin theme
 if [ -f "$DOTFILES_ROOT/theme/install.sh" ]; then
   echo "Installing Catppuccin theme..."

--- a/codex/config.toml
+++ b/codex/config.toml
@@ -24,6 +24,9 @@ review_model = "gpt-5.3-codex"
 
 # Experimental features that are useful for daily coding workflows.
 [features]
+# Include a lightweight shell state snapshot with command/tool context when useful.
 shell_snapshot = true
+# Route shell operations through the unified exec path for more consistent behavior.
 unified_exec = true
+# Enable local undo support for reversible edit operations in the CLI.
 undo = true

--- a/codex/config.toml
+++ b/codex/config.toml
@@ -21,7 +21,8 @@ personality = "pragmatic"
 # Increase reasoning depth for non-trivial coding tasks.
 model_reasoning_effort = "high"
 
-# Use a stronger model for /review runs.
+# Used when running `codex /review` (PR/diff review mode).
+# Normal coding/chat requests continue using `model` above.
 review_model = "gpt-5.3-codex"
 
 # Experimental features that are useful for daily coding workflows.

--- a/codex/config.toml
+++ b/codex/config.toml
@@ -9,7 +9,8 @@ model = "gpt-5.3-codex"
 approval_policy = "on-request"
 sandbox_mode = "workspace-write"
 
-# Use cached web search results by default to reduce injection exposure.
+# Use only cached/indexed web search snippets by default (no direct page fetches).
+# This reduces prompt-injection risk from arbitrary live web content.
 web_search = "cached"
 
 # Keep responses direct for terminal workflows.

--- a/codex/config.toml
+++ b/codex/config.toml
@@ -5,7 +5,9 @@
 # Keep a coding-focused default model.
 model = "gpt-5.3-codex"
 
-# Safe-by-default execution posture.
+# Safe-by-default execution posture:
+# - approval_policy="on-request": prompt before running commands outside the sandbox or with elevated risk.
+# - sandbox_mode="workspace-write": allow edits only in the workspace; block writes elsewhere by default.
 approval_policy = "on-request"
 sandbox_mode = "workspace-write"
 

--- a/codex/config.toml
+++ b/codex/config.toml
@@ -1,0 +1,28 @@
+# Codex CLI defaults
+# Symlinked to ~/.codex/config.toml by bootstrap.sh
+# Docs: https://developers.openai.com/codex/config-basic
+
+# Keep a coding-focused default model.
+model = "gpt-5.3-codex"
+
+# Safe-by-default execution posture.
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"
+
+# Use cached web search results by default to reduce injection exposure.
+web_search = "cached"
+
+# Keep responses direct for terminal workflows.
+personality = "pragmatic"
+
+# Increase reasoning depth for non-trivial coding tasks.
+model_reasoning_effort = "high"
+
+# Use a stronger model for /review runs.
+review_model = "gpt-5.3-codex"
+
+# Experimental features that are useful for daily coding workflows.
+[features]
+shell_snapshot = true
+unified_exec = true
+undo = true

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -64,6 +64,11 @@ setopt HIST_REDUCE_BLANKS
 autoload -Uz compinit && compinit
 zstyle ':completion:*' matcher-list 'm:{a-z}={A-Z}'
 
+# Codex CLI completion (safe no-op when codex isn't installed yet)
+if command -v codex >/dev/null; then
+  eval "$(codex completion zsh 2>/dev/null)"
+fi
+
 # Case-insensitive globbing
 setopt nocaseglob
 

--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -11,4 +11,4 @@ alias cx="codex"
 alias cxe="codex exec"
 alias cxr="codex resume --last"
 alias cxreview='codex "/review"'
-alias cxup='npm i -g @openai/codex@latest'
+alias cxup='if command -v brew >/dev/null && brew list --cask codex >/dev/null 2>&1; then brew upgrade --cask codex; else npm i -g @openai/codex@latest; fi'

--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -5,3 +5,10 @@ alias dtf="cd $DOTFILES"
 
 # Reload shell
 alias reload="exec zsh -l"
+
+# Codex CLI
+alias cx="codex"
+alias cxe="codex exec"
+alias cxr="codex resume --last"
+alias cxreview='codex "/review"'
+alias cxup='npm i -g @openai/codex@latest'


### PR DESCRIPTION
## Summary
This PR upgrades the dotfiles for a Codex-first AI development workflow while keeping security defaults conservative.

## What changed
- Added `codex/config.toml` and symlink wiring in `bootstrap.sh` to manage Codex defaults as dotfiles.
- Added Codex shell completions in `zsh/.zshrc` (safe no-op when Codex is not installed).
- Added Codex-focused aliases in `zsh/aliases.zsh` for common workflows.
- Expanded `README.md` with a new **Codex CLI Workflow** section, install command, defaults, shortcuts, and security guidance.
- Updated structure/features docs to include `codex/`.

## Codex defaults applied
- `model = "gpt-5.3-codex"`
- `approval_policy = "on-request"`
- `sandbox_mode = "workspace-write"`
- `web_search = "cached"`
- `review_model = "gpt-5.3-codex"`
- feature toggles: `shell_snapshot`, `unified_exec`, `undo`

## Why
- Faster day-to-day Codex terminal usage (`cx`, `cxe`, `cxr`, `cxreview`).
- Safer out-of-the-box behavior (no full-access defaults).
- Reproducible Codex setup across machines via dotfiles/bootstrap.

## Notes
- Codex installation is documented with the official npm path (`npm i -g @openai/codex`) from OpenAI docs.
- No risky defaults like `danger-full-access` / `--yolo` were introduced.
