### PR TITLE
feat: add Claude Code workflow support alongside Codex

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -44,4 +44,5 @@ cask "rectangle"        # Window manager
 cask "signal"
 cask "docker"
 cask "raycast"          # Productivity launcher
+cask "claude-code"      # Claude Code CLI (Anthropic)
 cask "font-fira-code-nerd-font" # Nerd font for icons (eza/starship)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The repository is organized into **topics**, making it easy to modularize your c
 - `ghostty/`: Ghostty terminal configuration (symlinked to `~/.config/ghostty/`).
 - `zed/`: Zed editor settings and keybindings (symlinked to `~/.config/zed/`).
 - `codex/`: Codex CLI configuration (symlinked to `~/.codex/`).
+- `claude/`: Claude Code settings (symlinked to `~/.claude/`).
 - `zsh/`: Zsh configuration, plugins, and modular initialization.
 
 ## Features
@@ -34,6 +35,7 @@ The repository is organized into **topics**, making it easy to modularize your c
 - **Ghostty terminal**: GPU-accelerated terminal with Catppuccin theme, Fira Code font, and custom keybindings — fully configured as dotfiles.
 - **Zed editor**: Primary editor with Catppuccin theme, Fira Code font, Prettier formatting, and custom keybindings — all managed as dotfiles.
 - **Codex CLI workflow**: Safe-by-default Codex config, shell shortcuts, and completion for day-to-day AI coding.
+- **Claude Code workflow**: Claude Code settings + shell shortcuts tuned for regular use alongside Codex.
 
 ## Ghostty Terminal
 
@@ -98,6 +100,35 @@ npm i -g @openai/codex  # cross-platform alternative
 - `cxup` → upgrade Codex CLI (uses Homebrew cask when Codex was installed with brew; otherwise npm)
 
 > Security note: This setup intentionally avoids `danger-full-access` / `--yolo` defaults.
+
+## Claude Code Workflow
+
+[Claude Code](https://code.claude.com/docs/en/setup) is configured for a reliable daily-driver workflow that can coexist with Codex.
+
+| File | Destination | Purpose |
+|------|-------------|---------|
+| `claude/settings.json` | `~/.claude/settings.json` | Update channel and attribution preferences |
+
+**Install Claude Code CLI:**
+
+```bash
+brew install --cask claude-code
+# or native installer (recommended by Anthropic):
+curl -fsSL https://claude.ai/install.sh | bash
+```
+
+**Key defaults in this repo:**
+- `$schema` enabled for editor validation/autocomplete
+- `autoUpdatesChannel = "stable"` to reduce surprise regressions
+- `attribution.commit` / `attribution.pr` are blanked to avoid automatic AI bylines in commits/PRs
+
+**Zsh shortcuts:**
+- `cc` → `claude`
+- `ccr` → `claude --resume`
+- `ccdoctor` → `claude doctor`
+- `ccupdate` → upgrade Claude Code (brew cask if installed via Homebrew, otherwise `claude update`)
+
+> Workflow note: Codex and Claude configs are independent (`~/.codex/` and `~/.claude/`), so switching between them is frictionless.
 
 ## Zed Editor
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ npm i -g @openai/codex  # cross-platform alternative
 - `cxreview` → start Codex with `/review`
 - `cxup` → upgrade Codex CLI (uses Homebrew cask when Codex was installed with brew; otherwise npm)
 
-> Security note: This setup intentionally avoids `danger-full-access` / `--yolo` defaults.
+> Security note: This setup intentionally avoids `danger-full-access` / `--yolo` defaults, and `sandbox_mode = "workspace-write"` prevents destructive commands like `rm -rf ~/` from writing outside the workspace.
 
 ## Claude Code Workflow
 
@@ -124,7 +124,7 @@ curl -fsSL https://claude.ai/install.sh | bash
 - `respectGitignore = true` to keep ignored/private files out of file suggestions
 - `permissions.disableBypassPermissionsMode = "disable"` to block bypass mode
 - `permissions.ask` prompts on high-risk network/sensitive reads (`git push`, `curl`, `wget`, `.env`, `./secrets/**`)
-- `permissions.deny` blocks obviously dangerous shell patterns (`sudo *`, `rm -rf /`)
+- `permissions.deny` blocks obviously dangerous shell patterns (`sudo *`, `rm -rf /`, `rm -rf ~/`)
 - `attribution.commit` / `attribution.pr` are blanked to avoid automatic AI bylines in commits/PRs
 
 **Zsh shortcuts:**

--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ curl -fsSL https://claude.ai/install.sh | bash
 **Key defaults in this repo:**
 - `$schema` enabled for editor validation/autocomplete
 - `autoUpdatesChannel = "stable"` to reduce surprise regressions
+- `cleanupPeriodDays = 30` to avoid keeping transcripts indefinitely
+- `respectGitignore = true` to keep ignored/private files out of file suggestions
+- `permissions.disableBypassPermissionsMode = "disable"` to block bypass mode
+- `permissions.ask` prompts on high-risk network/sensitive reads (`git push`, `curl`, `wget`, `.env`, `./secrets/**`)
+- `permissions.deny` blocks obviously dangerous shell patterns (`sudo *`, `rm -rf /`)
 - `attribution.commit` / `attribution.pr` are blanked to avoid automatic AI bylines in commits/PRs
 
 **Zsh shortcuts:**

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -52,6 +52,10 @@ ln -sf "$DOTFILES_ROOT/ghostty/config" "$HOME/.config/ghostty/config"
 mkdir -p "$HOME/.codex"
 ln -sf "$DOTFILES_ROOT/codex/config.toml" "$HOME/.codex/config.toml"
 
+# Claude Code CLI
+mkdir -p "$HOME/.claude"
+ln -sf "$DOTFILES_ROOT/claude/settings.json" "$HOME/.claude/settings.json"
+
 # 4. Install Catppuccin theme
 if [ -f "$DOTFILES_ROOT/theme/install.sh" ]; then
   echo "Installing Catppuccin theme..."

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,8 +1,25 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "autoUpdatesChannel": "stable",
+  "cleanupPeriodDays": 30,
+  "respectGitignore": true,
   "attribution": {
     "commit": "",
     "pr": ""
+  },
+  "permissions": {
+    "defaultMode": "default",
+    "disableBypassPermissionsMode": "disable",
+    "ask": [
+      "Bash(git push *)",
+      "Bash(curl *)",
+      "Bash(wget *)",
+      "Read(./.env)",
+      "Read(./secrets/**)"
+    ],
+    "deny": [
+      "Bash(rm -rf /)",
+      "Bash(sudo *)"
+    ]
   }
 }

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "autoUpdatesChannel": "stable",
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  }
+}

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -19,6 +19,7 @@
     ],
     "deny": [
       "Bash(rm -rf /)",
+      "Bash(rm -rf ~/)",
       "Bash(sudo *)"
     ]
   }

--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -12,3 +12,9 @@ alias cxe="codex exec"
 alias cxr="codex resume --last"
 alias cxreview='codex "/review"'
 alias cxup='if command -v brew >/dev/null && brew list --cask codex >/dev/null 2>&1; then brew upgrade --cask codex; else npm i -g @openai/codex@latest; fi'
+
+# Claude Code CLI
+alias cc="claude"
+alias ccr="claude --resume"
+alias ccdoctor="claude doctor"
+alias ccupdate='if command -v brew >/dev/null && brew list --cask claude-code >/dev/null 2>&1; then brew upgrade --cask claude-code; else claude update; fi'


### PR DESCRIPTION
## Summary
Adds first-class Claude Code workflow support to dotfiles so switching between Codex and Claude stays smooth.

## What changed
- Added `claude/settings.json` and symlink wiring in `bootstrap.sh` to manage Claude user settings via dotfiles.
- Added `claude-code` cask to `Brewfile`.
- Added Claude-focused aliases in `zsh/aliases.zsh`:
  - `cc` (`claude`)
  - `ccr` (`claude --resume`)
  - `ccdoctor` (`claude doctor`)
  - `ccupdate` (brew upgrade when installed via Homebrew, fallback to `claude update`)
- Expanded `README.md` with a dedicated **Claude Code Workflow** section, install options, defaults, and coexistence notes with Codex.

## Claude settings defaults
`claude/settings.json` includes:
- JSON schema reference (`https://json.schemastore.org/claude-code-settings.json`)
- `autoUpdatesChannel: "stable"` (lower regression risk)
- blank attribution for commit/PR bylines

## Why
- You mentioned switching regularly between Codex and Claude Code.
- This keeps both tools configured, documented, and easy to update from the same dotfiles workflow.
- Maintains a conservative, stable default posture.
