### PR TITLE
feat: make mise a first-class dotfiles workflow tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The repository is organized into **topics**, making it easy to modularize your c
 - `vim/`: Vim configuration.
 - `ghostty/`: Ghostty terminal configuration (symlinked to `~/.config/ghostty/`).
 - `zed/`: Zed editor settings and keybindings (symlinked to `~/.config/zed/`).
+- `mise/`: Mise global config (symlinked to `~/.config/mise/`).
 - `codex/`: Codex CLI configuration (symlinked to `~/.codex/`).
 - `claude/`: Claude Code settings (symlinked to `~/.claude/`).
 - `zsh/`: Zsh configuration, plugins, and modular initialization.
@@ -30,7 +31,7 @@ The repository is organized into **topics**, making it easy to modularize your c
 - **Modern CLI tools**: Integrated with `eza`, `bat`, `fzf`, `zoxide`, and `starship`.
 - **Zsh Power-ups**: Syntax highlighting and autosuggestions out of the box.
 - **Auto-update**: Automatically checks for updates to your dotfiles once a day.
-- **Mise integration**: Blazing fast management for Node, Ruby, Python, and more.
+- **Mise integration**: Configured global settings + project tool/tasks for reproducible shell workflows.
 - **Advanced Git**: Includes `gh-dash` and powerful log visualization.
 - **Ghostty terminal**: GPU-accelerated terminal with Catppuccin theme, Fira Code font, and custom keybindings — fully configured as dotfiles.
 - **Zed editor**: Primary editor with Catppuccin theme, Fira Code font, Prettier formatting, and custom keybindings — all managed as dotfiles.
@@ -64,6 +65,36 @@ The repository is organized into **topics**, making it easy to modularize your c
 | `cmd+0` | Reset font size |
 
 > **Note:** `theme/iterm2-catppuccin.json` is preserved in the repo for historical reference but is no longer used.
+
+## Mise Workflow
+
+[mise](https://mise.jdx.dev/) is now wired as an active part of this repo instead of just being installed.
+
+| File | Destination | Purpose |
+|------|-------------|---------|
+| `mise/config.toml` | `~/.config/mise/config.toml` | Global mise behavior/settings |
+| `mise.toml` | `~/dotfiles/mise.toml` | Project tools + tasks for dotfiles maintenance |
+
+**Best-practice defaults applied (from official mise docs):**
+- `auto_install = true` for smoother `mise run` / `mise exec` workflows
+- `env_cache = true` and `env_cache_ttl = "2h"` for faster repeated prompt/env resolution
+- `color_theme = "catppuccin"` to match terminal/editor theme choices
+- `min_version` soft floor in project config to reduce config drift
+
+**Project tools managed by mise:**
+- `shellcheck`
+- `shfmt`
+
+**Project tasks:**
+- `mise run mise-install` → install configured tools
+- `mise run lint-shell` → lint shell scripts
+- `mise run fmt-shell` → format shell scripts
+- `mise run doctor` → run diagnostics
+
+**Shell helpers:**
+- `ms` / `msi` / `msu` / `msr` / `msd`
+
+> Note: `mise activate zsh` is intentionally loaded near the end of `.zshrc` so later PATH edits don’t override mise-managed tool versions.
 
 ## Codex CLI Workflow
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -48,6 +48,10 @@ ln -sf "$DOTFILES_ROOT/zed/keymap.json" "$HOME/.config/zed/keymap.json"
 mkdir -p "$HOME/.config/ghostty"
 ln -sf "$DOTFILES_ROOT/ghostty/config" "$HOME/.config/ghostty/config"
 
+# Mise
+mkdir -p "$HOME/.config/mise"
+ln -sf "$DOTFILES_ROOT/mise/config.toml" "$HOME/.config/mise/config.toml"
+
 # Codex CLI
 mkdir -p "$HOME/.codex"
 ln -sf "$DOTFILES_ROOT/codex/config.toml" "$HOME/.codex/config.toml"

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,29 @@
+# Project-specific mise config for this dotfiles repository
+# Docs: https://mise.jdx.dev/configuration.html
+
+min_version = { soft = "2025.1.0" }
+
+[tools]
+# Shell tooling used for dotfiles maintenance
+shellcheck = "latest"
+shfmt = "latest"
+
+[tasks.mise-install]
+description = "Install tools from mise.toml"
+run = "mise install"
+
+[tasks.lint-shell]
+description = "Lint shell scripts in this repo"
+run = [
+  "shellcheck bootstrap.sh theme/install.sh zsh/.zshrc zsh/*.zsh system/auto-update.zsh",
+]
+
+[tasks.fmt-shell]
+description = "Format shell scripts in this repo"
+run = [
+  "shfmt -w bootstrap.sh theme/install.sh zsh/.zshrc zsh/*.zsh system/auto-update.zsh",
+]
+
+[tasks.doctor]
+description = "Run mise diagnostics"
+run = "mise doctor"

--- a/mise/config.toml
+++ b/mise/config.toml
@@ -1,0 +1,13 @@
+# Global mise settings (symlinked to ~/.config/mise/config.toml)
+# Docs: https://mise.jdx.dev/configuration/settings.html
+
+[settings]
+# Automatically install missing tools for `mise run` / `mise exec` workflows.
+auto_install = true
+
+# Cache resolved environment for faster prompt/hooks in large repos.
+env_cache = true
+env_cache_ttl = "2h"
+
+# Match terminal theme family used across this dotfiles repo.
+color_theme = "catppuccin"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -20,12 +20,7 @@ for file in $DOTFILES/**/*.path; do
     source "$file"
 done
 
-# 2. Load mise (version manager)
-if command -v mise >/dev/null; then
-  eval "$(mise activate zsh)"
-fi
-
-# 3. Load all other .zsh files (except plugins/completion)
+# 2. Load all other .zsh files (except plugins/completion)
 for file in $DOTFILES/**/*.zsh(N); do
     if [[ "$file" != *"plugins.zsh"* && "$file" != *"completion.zsh"* ]]; then
         source "$file"
@@ -50,6 +45,12 @@ fi
 
 # plugins
 source "$DOTFILES/zsh/plugins.zsh"
+
+# mise (version manager)
+# Keep activation near the end so later PATH edits don't override mise tools.
+if command -v mise >/dev/null; then
+  eval "$(mise activate zsh)"
+fi
 
 # --- Zsh Specifics ---
 HISTFILE=~/.zsh_history

--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -18,3 +18,10 @@ alias cc="claude"
 alias ccr="claude --resume"
 alias ccdoctor="claude doctor"
 alias ccupdate='if command -v brew >/dev/null && brew list --cask claude-code >/dev/null 2>&1; then brew upgrade --cask claude-code; else claude update; fi'
+
+# Mise
+alias ms="mise"
+alias msi="mise install"
+alias msu="mise upgrade"
+alias msr="mise run"
+alias msd="mise doctor"


### PR DESCRIPTION
## Summary
Turns mise from "installed but mostly unused" into an active part of the dotfiles workflow, based on official mise guidance.

## What changed
- Added `mise/config.toml` (global config, symlinked to `~/.config/mise/config.toml`)
- Added repo-level `mise.toml` with:
  - `min_version` recommendation
  - project tools: `shellcheck`, `shfmt`
  - project tasks: `mise-install`, `lint-shell`, `fmt-shell`, `doctor`
- Updated `bootstrap.sh` to symlink `mise/config.toml`
- Updated `.zshrc` to keep `mise activate zsh` near the end (prevents later PATH edits from overriding mise-managed tools)
- Added useful mise aliases in `zsh/aliases.zsh`: `ms`, `msi`, `msu`, `msr`, `msd`
- Expanded README with a dedicated **Mise Workflow** section and usage docs

## Best-practice rationale (official mise docs)
- Use `mise.toml` for project-scoped tools/tasks
- Use global config for user-level settings
- Keep shell activation in a position that preserves PATH precedence
- Lean on tasks for reproducible project maintenance commands
- Enable env caching for faster repeated environment resolution

## Notes
This keeps behavior conservative (no experimental flags, no invasive global overrides), while making mise immediately useful in this repo.
