### PR TITLE
feat: add practical fzf workflows for terminal productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The repository is organized into **topics**, making it easy to modularize your c
 
 - **Topic-based organization**: Modular and easy to maintain.
 - **Modern CLI tools**: Integrated with `eza`, `bat`, `fzf`, `zoxide`, and `starship`.
+- **FZF workflows**: Fast file/dir navigation, branch switching, ripgrep jump-to-file, and process kill helpers.
 - **Zsh Power-ups**: Syntax highlighting and autosuggestions out of the box.
 - **Auto-update**: Automatically checks for updates to your dotfiles once a day.
 - **Mise integration**: Configured global settings + project tool/tasks for reproducible shell workflows.
@@ -65,6 +66,19 @@ The repository is organized into **topics**, making it easy to modularize your c
 | `cmd+0` | Reset font size |
 
 > **Note:** `theme/iterm2-catppuccin.json` is preserved in the repo for historical reference but is no longer used.
+
+## FZF Workflow
+
+`fzf` is already installed via Brewfile; this repo now includes practical shell functions in `system/.functions` tailored for your setup (`bat`, `rg`, `zed`, git-heavy workflow).
+
+**Included functions:**
+- `ff` → fuzzy-find file and open in Zed (fallback: VS Code / `$EDITOR`)
+- `fcd` → fuzzy-find directory and `cd` into it
+- `fbr` → fuzzy-switch git branches (supports remote tracking branches)
+- `frg [query]` → fuzzy-select from `rg` results and jump to file+line
+- `fkill` → fuzzy-select running process and kill it
+
+These are designed for daily terminal usage with your current tooling stack and should work across your repos out of the box.
 
 ## Mise Workflow
 

--- a/system/.functions
+++ b/system/.functions
@@ -183,3 +183,78 @@ function cflogs() {
     curl -H "Authorization: Bearer ${CLOUDFLARE_TOKEN}" https://api.cloudflare.com/client/v4/zones/e8900cc9c0e8dc2ade675327b3f634fa/logs/rayids/$1
 }
 
+# FZF WORKFLOWS
+
+# Fuzzy-find file and open in Zed
+function ff() {
+    local file
+    file=$(find . -type f \
+        -not -path '*/.git/*' \
+        -not -path '*/node_modules/*' \
+        -not -path '*/.mise/*' \
+        2>/dev/null | fzf --height=50% --layout=reverse --border --preview 'bat --style=numbers --color=always --line-range=:200 {}' --preview-window=right:60%) || return 1
+
+    if command -v zed >/dev/null; then
+        zed "$file"
+    elif command -v code >/dev/null; then
+        code "$file"
+    else
+        ${EDITOR:-vim} "$file"
+    fi
+}
+
+# Fuzzy-find directory and cd into it
+function fcd() {
+    local dir
+    dir=$(find . -type d \
+        -not -path '*/.git/*' \
+        -not -path '*/node_modules/*' \
+        -not -path '*/.mise/*' \
+        2>/dev/null | fzf --height=50% --layout=reverse --border) || return 1
+    cd "$dir" || return 1
+}
+
+# Fuzzy-switch git branch
+function fbr() {
+    local branch
+    branch=$(git for-each-ref --sort=-committerdate refs/heads refs/remotes --format='%(refname:short)' \
+        | grep -v '^origin/HEAD$' \
+        | fzf --height=50% --layout=reverse --border --preview 'git log --oneline --decorate -n 20 {}') || return 1
+
+    # If selecting a remote branch, create/tracking checkout
+    if [[ "$branch" == origin/* ]]; then
+        git checkout --track "$branch"
+    else
+        git checkout "$branch"
+    fi
+}
+
+# Fuzzy-search ripgrep results and open selected file:line
+function frg() {
+    local query selected file line
+    query="${1:-}"
+    selected=$(rg --line-number --no-heading --color=always --smart-case "$query" . \
+        | fzf --ansi --height=60% --layout=reverse --border \
+              --delimiter ':' \
+              --preview 'bat --style=numbers --color=always {1} --highlight-line {2}' \
+              --preview-window=right:60%) || return 1
+
+    file=$(echo "$selected" | awk -F: '{print $1}')
+    line=$(echo "$selected" | awk -F: '{print $2}')
+
+    if command -v zed >/dev/null; then
+        zed "$file:$line"
+    elif command -v code >/dev/null; then
+        code -g "$file:$line"
+    else
+        ${EDITOR:-vim} "+$line" "$file"
+    fi
+}
+
+# Fuzzy pick process and kill it
+function fkill() {
+    local pid
+    pid=$(ps -ef | sed 1d | fzf --height=50% --layout=reverse --border --preview 'echo {}' | awk '{print $2}') || return 1
+    kill -9 "$pid"
+}
+


### PR DESCRIPTION
## Summary
Adds practical, high-signal `fzf` helper functions aligned with your current terminal/editor/tooling stack.

## What changed
- Added new `fzf`-powered functions in `system/.functions`:
  - `ff` → fuzzy-find file and open in Zed (fallback: VS Code / `$EDITOR`)
  - `fcd` → fuzzy-find directory and `cd`
  - `fbr` → fuzzy-switch git branches (with remote branch handling)
  - `frg [query]` → fuzzy-select from ripgrep results and jump to file+line
  - `fkill` → fuzzy-select process and kill it
- Added an **FZF Workflow** section to `README.md` documenting these commands.
- Updated Features list to include new FZF workflows.

## Why
You asked for generally useful fuzzy-search aliases/functions based on your existing dotfiles utilities (`fzf`, `bat`, `rg`, `git`, `zed`).

These helpers target common daily actions:
- jump to files quickly,
- navigate to directories,
- switch branches,
- hop from search result to code line,
- kill runaway processes.

## Notes
- Previews use `bat` where available.
- Commands gracefully fall back to `code` / `$EDITOR` when `zed` is unavailable.
