### PR TITLE
feat: add zsh-ai with Anthropic defaults

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -23,8 +23,8 @@ brew "gh"
 brew "commitizen"
 
 # Modern CLI Enhancements
-brew "fzf"              # Fuzzy finder
-brew "fd"               # Better 'find'
+brew "fzf"              # Interactive fuzzy selector (pick from lists)
+brew "fd"               # Fast file discovery (complements fzf; not a replacement)
 brew "zoxide"           # Better 'cd'
 brew "bat"              # Better 'cat'
 brew "eza"              # Better 'ls'

--- a/Brewfile
+++ b/Brewfile
@@ -3,6 +3,7 @@
 # Taps
 tap "homebrew/bundle"
 tap "homebrew/cask-versions"
+tap "matheusml/zsh-ai"
 
 # CLI Tools (Core)
 brew "coreutils"
@@ -23,6 +24,7 @@ brew "commitizen"
 
 # Modern CLI Enhancements
 brew "fzf"              # Fuzzy finder
+brew "fd"               # Better 'find'
 brew "zoxide"           # Better 'cd'
 brew "bat"              # Better 'cat'
 brew "eza"              # Better 'ls'
@@ -30,6 +32,7 @@ brew "mise"             # Universal version manager
 brew "starship"         # Fast, minimal shell prompt
 brew "speedtest-cli"
 brew "gh-dash"          # GitHub CLI dashboard extension
+brew "zsh-ai"           # Natural language → shell command helper
 
 # Casks (Apps)
 cask "ghostty"           # GPU-accelerated terminal (replaces iTerm2)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The repository is organized into **topics**, making it easy to modularize your c
 - **Zed editor**: Primary editor with Catppuccin theme, Fira Code font, Prettier formatting, and custom keybindings — all managed as dotfiles.
 - **Codex CLI workflow**: Safe-by-default Codex config, shell shortcuts, and completion for day-to-day AI coding.
 - **Claude Code workflow**: Claude Code settings + shell shortcuts tuned for regular use alongside Codex.
+- **zsh-ai workflow**: Natural-language command generation in terminal using Anthropic by default.
 
 ## Ghostty Terminal
 
@@ -79,6 +80,33 @@ The repository is organized into **topics**, making it easy to modularize your c
 - `fkill` → fuzzy-select running process and kill it
 
 These are designed for daily terminal usage with your current tooling stack and should work across your repos out of the box.
+
+## zsh-ai Workflow
+
+[zsh-ai](https://github.com/matheusml/zsh-ai) is integrated as a shell plugin with Anthropic defaults tuned for your existing CLI stack.
+
+| File | Purpose |
+|------|---------|
+| `zsh/zsh-ai.zsh` | Provider/model defaults, prompt preferences, API key loading |
+
+**Install path**
+- Homebrew tap: `matheusml/zsh-ai`
+- Formula: `zsh-ai`
+- Plugin sourced from: `$(brew --prefix)/share/zsh-ai/zsh-ai.plugin.zsh`
+
+**Defaults configured:**
+- `ZSH_AI_PROVIDER="anthropic"`
+- `ZSH_AI_ANTHROPIC_MODEL="claude-haiku-4-5"`
+- `ZSH_AI_ANTHROPIC_URL="https://api.anthropic.com/v1/messages"`
+- `ZSH_AI_PROMPT_EXTEND` tuned to your tools (`rg`, `fd`, `bat`, `eza`, `zed`)
+
+**API key handling (secure-by-default):**
+- Uses existing `ANTHROPIC_API_KEY` if already set
+- Otherwise loads from `~/.config/anthropic/api_key` (single-line key file)
+- No API key is stored in git or committed dotfiles
+
+**Usage:**
+- Type `# what you want` and press Enter, or run `zsh-ai "your request"`
 
 ## Mise Workflow
 

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -43,6 +43,11 @@ if command -v starship >/dev/null; then
   eval "$(starship init zsh)"
 fi
 
+# zsh-ai plugin (Homebrew install path)
+if command -v brew >/dev/null && [[ -r "$(brew --prefix)/share/zsh-ai/zsh-ai.plugin.zsh" ]]; then
+  source "$(brew --prefix)/share/zsh-ai/zsh-ai.plugin.zsh"
+fi
+
 # plugins
 source "$DOTFILES/zsh/plugins.zsh"
 

--- a/zsh/zsh-ai.zsh
+++ b/zsh/zsh-ai.zsh
@@ -1,0 +1,21 @@
+# zsh-ai defaults
+# Docs: https://github.com/matheusml/zsh-ai
+
+# Use Anthropic by default
+export ZSH_AI_PROVIDER="anthropic"
+
+# Fast + capable default model for shell command generation
+export ZSH_AI_ANTHROPIC_MODEL="claude-haiku-4-5"
+
+# Official API endpoint (override if needed)
+export ZSH_AI_ANTHROPIC_URL="https://api.anthropic.com/v1/messages"
+
+# Make generated commands align with this dotfiles stack
+export ZSH_AI_PROMPT_EXTEND="Prefer modern tools available on this machine: rg over grep, fd over find when appropriate, bat over cat, eza over ls, and zed for opening files."
+
+# API key loading strategy (in priority order):
+# 1) Existing ANTHROPIC_API_KEY in environment
+# 2) ~/.config/anthropic/api_key file (single-line key)
+if [[ -z "$ANTHROPIC_API_KEY" && -f "$HOME/.config/anthropic/api_key" ]]; then
+  export ANTHROPIC_API_KEY="$(<"$HOME/.config/anthropic/api_key")"
+fi


### PR DESCRIPTION
## Summary
Adds `zsh-ai` to dotfiles with Anthropic as the default provider and productive defaults tuned for your terminal workflow.

## What changed
- **Brewfile**
  - Added tap: `matheusml/zsh-ai`
  - Added formula: `zsh-ai`
  - Added `fd` (used by zsh-ai prompt preferences)

- **Shell integration** (`zsh/.zshrc`)
  - Sources zsh-ai plugin from Homebrew path when available:
    - `$(brew --prefix)/share/zsh-ai/zsh-ai.plugin.zsh`

- **zsh-ai config** (`zsh/zsh-ai.zsh`)
  - `ZSH_AI_PROVIDER="anthropic"`
  - `ZSH_AI_ANTHROPIC_MODEL="claude-haiku-4-5"`
  - `ZSH_AI_ANTHROPIC_URL="https://api.anthropic.com/v1/messages"`
  - `ZSH_AI_PROMPT_EXTEND` set to prefer your modern CLI tools (`rg`, `fd`, `bat`, `eza`, `zed`)
  - Secure key-loading flow:
    1. use existing `ANTHROPIC_API_KEY` if set
    2. else load from `~/.config/anthropic/api_key`

- **README**
  - Added a full **zsh-ai Workflow** section with install path, defaults, API key strategy, and usage.

## Security note
No API keys are committed to git. This PR intentionally wires secure key loading rather than storing a literal key in dotfiles.

## Usage after bootstrap/reload
- Comment style: type `# your command request` and press Enter
- Direct style: `zsh-ai "your request"`
