### PR TITLE
chore: add requested casks and brew packages to Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -22,6 +22,13 @@ brew "git-lfs"
 brew "gh"
 brew "commitizen"
 brew "pre-commit"       # Deterministic pre-commit checks
+brew "cloudflared"
+brew "docker"
+brew "gitmoji"
+brew "go"
+brew "jq"
+brew "oath-toolkit"
+brew "openvpn"
 
 # Modern CLI Enhancements
 brew "fzf"              # Interactive fuzzy selector (pick from lists)
@@ -31,7 +38,7 @@ brew "bat"              # Better 'cat'
 brew "eza"              # Better 'ls'
 brew "mise"             # Universal version manager
 brew "starship"         # Fast, minimal shell prompt
-brew "speedtest-cli"
+brew "speedtest"
 brew "gh-dash"          # GitHub CLI dashboard extension
 brew "zsh-ai"           # Natural language → shell command helper
 brew "doggo"            # Modern DNS client (dig replacement for daily use)
@@ -41,6 +48,15 @@ brew "iperf3"           # Throughput testing
 # Casks (Apps)
 cask "ghostty"           # GPU-accelerated terminal (replaces iTerm2)
 cask "codex"             # OpenAI Codex CLI
+cask "1password-cli"
+cask "chatgpt-atlas"
+cask "discord"
+cask "docker-desktop"
+cask "grandperspective"
+cask "lulu"
+cask "raindropio"
+cask "tradingview"
+cask "wribe"
 cask "brave-browser"
 cask "google-chrome"
 cask "zed"
@@ -49,7 +65,6 @@ cask "spotify"
 cask "postman"
 cask "rectangle"        # Window manager
 cask "signal"
-cask "docker"
 cask "wireshark"        # GUI packet analysis
 cask "raycast"          # Productivity launcher
 cask "claude-code"      # Claude Code CLI (Anthropic)

--- a/Brewfile
+++ b/Brewfile
@@ -50,6 +50,7 @@ cask "ghostty"           # GPU-accelerated terminal (replaces iTerm2)
 cask "codex"             # OpenAI Codex CLI
 cask "1password-cli"
 cask "chatgpt-atlas"
+cask "comet"
 cask "discord"
 cask "docker-desktop"
 cask "grandperspective"


### PR DESCRIPTION
## Summary
Adds the requested casks and brew packages to the dotfiles `Brewfile`, and replaces `speedtest-cli` with `speedtest`.

## Casks added
- `1password-cli`
- `chatgpt-atlas`
- `discord`
- `docker-desktop`
- `grandperspective`
- `lulu`
- `raindropio`
- `tradingview`
- `wribe`

## Brew packages added
- `cloudflared`
- `docker`
- `gitmoji`
- `go`
- `jq`
- `oath-toolkit`
- `openvpn`

## Replacement
- Replaced `brew "speedtest-cli"` with `brew "speedtest"`

## Note
- Swapped `cask "docker"` to `cask "docker-desktop"` per your requested cask list.
