### PR TITLE
chore: final readiness hardening pass for dotfiles setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ cd ~/dotfiles
 ./bootstrap.sh
 ```
 
+`bootstrap.sh` is path-safe and uses the repository root internally, so it can be re-run reliably even when invoked from different working directories.
+
 ## Structure
 
 The repository is organized into **topics**, making it easy to modularize your configuration:
@@ -82,7 +84,7 @@ This repo now includes a lightweight, practical network-debug toolkit for daily 
 - `mtr` — traceroute + ping combined
 - `iperf3` — throughput testing
 
-Use your existing aliases for basics (`ip`, `lip`, `ips`, `flushdns`), and call modern tools directly (`doggo`, `curl`, `tcpdump`).
+Use your existing aliases for basics (`ip`, `lip`, `ips`, `flushdns`), and call modern tools directly (`doggo`, `curl`, `tcpdump`). (`flushdns` runs both `dscacheutil` and `mDNSResponder` refresh.)
 
 **Network functions (`system/.functions`):**
 - `dnstrace <domain>` — DNS trace path

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 # bootstrap.sh - Topic-based setup for ibarsi
 
-DOTFILES_ROOT=$(pwd -P)
+DOTFILES_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+cd "$DOTFILES_ROOT"
 
 # 1. Install Homebrew if not present
-if ! command -v brew >/dev/null; then
+if ! command -v brew >/dev/null 2>&1; then
   echo "Installing Homebrew..."
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
   
@@ -18,7 +20,7 @@ fi
 
 # 2. Install all tools and apps from Brewfile
 echo "Syncing tools from Brewfile..."
-brew bundle
+brew bundle --file "$DOTFILES_ROOT/Brewfile"
 
 # 3. Create symlinks
 # We use a simple loop to find files we want to link to $HOME
@@ -69,13 +71,18 @@ else
 fi
 
 # 5. Set Zsh as default shell
-if [ "$SHELL" != "$(which zsh)" ]; then
+ZSH_PATH="$(command -v zsh || true)"
+if [ -n "$ZSH_PATH" ] && [ "$SHELL" != "$ZSH_PATH" ]; then
   echo "Setting Zsh as default shell..."
-  chsh -s "$(which zsh)"
+  chsh -s "$ZSH_PATH"
 fi
 
 # 6. Apply macOS defaults
-echo "Applying macOS defaults (requires sudo)..."
-./macos/.macos
+if [ -f "$DOTFILES_ROOT/macos/.macos" ]; then
+  echo "Applying macOS defaults (requires sudo)..."
+  bash "$DOTFILES_ROOT/macos/.macos"
+else
+  echo "macOS defaults script not found, skipping..."
+fi
 
 echo "Setup complete! Restart your terminal to see changes."

--- a/system/.aliases
+++ b/system/.aliases
@@ -126,7 +126,7 @@ alias npmls='npm ls -g --depth=0 --silent --parseable | xargs basename | grep -v
 alias fixtime='sudo ntpdate -u time.apple.com'
 
 # Clear DNS cache
-alias flushdns='sudo killall -HUP mDNSResponder'
+alias flushdns='sudo dscacheutil -flushcache; sudo killall -HUP mDNSResponder'
 
 # Gitmoji
 alias gm='gitmoji'

--- a/system/.functions
+++ b/system/.functions
@@ -1,9 +1,21 @@
 #!/usr/bin/env bash
 
 # Kill process by port
-function killport()
-{
-    lsof -i tcp:$1 | awk 'FNR == 2 {print $2}' | xargs kill -9
+function killport() {
+    if [[ -z "${1:-}" ]]; then
+        echo "Usage: killport <port>"
+        return 1
+    fi
+
+    local pids
+    pids=$(lsof -ti tcp:"$1")
+
+    if [[ -z "$pids" ]]; then
+        echo "No process is listening on TCP port $1"
+        return 0
+    fi
+
+    echo "$pids" | xargs kill -9
 }
 
 # Toggle "focus mode"


### PR DESCRIPTION
## Summary
Final readiness hardening pass for dotfiles before new-machine setup.

This PR focuses on real reliability/consistency issues (not stylistic churn):
- bootstrap execution safety and path robustness
- shell helper edge-case handling
- minor docs consistency updates

## Findings and fixes

### 1) `bootstrap.sh` assumed current working directory
**Issue:** `DOTFILES_ROOT=$(pwd -P)` could point to the wrong location if bootstrap was invoked from a different directory.

**Fix:**
- Resolve root from script location: `BASH_SOURCE[0]`
- `cd "$DOTFILES_ROOT"` before relative operations
- `brew bundle --file "$DOTFILES_ROOT/Brewfile"`

### 2) Bootstrap resilience and safer shell behavior
**Issue:** Script could continue after partial failures, and used `which zsh` (less robust).

**Fix:**
- Added `set -euo pipefail`
- Switched to `command -v zsh`
- Guarded zsh default-shell change when zsh is available

### 3) macOS defaults invocation robustness
**Issue:** `./macos/.macos` depended on cwd and lacked a missing-file guard.

**Fix:**
- Execute via absolute repo path
- Skip gracefully if script missing

### 4) `flushdns` alias completeness
**Issue:** only `mDNSResponder` refresh was used.

**Fix:**
- Updated alias to run both `dscacheutil -flushcache` and `killall -HUP mDNSResponder`

### 5) `killport` helper reliability
**Issues:**
- no usage check
- only killed one PID (`FNR == 2`)
- noisy behavior when no process matched

**Fix:**
- Added usage validation
- Capture all listening PIDs via `lsof -ti`
- Clear output for no-match case

### 6) README consistency touch-ups
- Added note that bootstrap is now path-safe/re-runnable
- Clarified `flushdns` behavior

## Validation
- `bash -n bootstrap.sh`
- `bash -n system/.functions`
- `bash -n system/auto-update.zsh`

No behavior-breaking refactors; this is a reliability pass to reduce setup surprises on a fresh machine.
