### PR TITLE
chore: preflight minimalism cleanup before new machine setup

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -23,7 +23,6 @@ brew "gh"
 brew "commitizen"
 brew "pre-commit"       # Deterministic pre-commit checks
 brew "cloudflared"
-brew "docker"
 brew "gitmoji"
 brew "go"
 brew "jq"
@@ -49,6 +48,7 @@ brew "iperf3"           # Throughput testing
 cask "ghostty"           # GPU-accelerated terminal (replaces iTerm2)
 cask "codex"             # OpenAI Codex CLI
 cask "1password-cli"
+# Optional/newer casks (higher rename/churn risk over time)
 cask "chatgpt-atlas"
 cask "comet"
 cask "discord"

--- a/system/.aliases
+++ b/system/.aliases
@@ -62,6 +62,4 @@ alias flushdns='sudo dscacheutil -flushcache; sudo killall -HUP mDNSResponder'
 # Gitmoji
 alias gm='gitmoji'
 
-# See what's listening on a given port
-# (implemented as function `whichport` in system/.functions)
 

--- a/system/.aliases
+++ b/system/.aliases
@@ -5,7 +5,6 @@ alias ..="cd .."
 alias ...="cd ../.."
 alias ....="cd ../../.."
 alias .....="cd ../../../.."
-alias -- -="cd -"
 
 # Shortcuts
 alias cdd="cd ~/Desktop"
@@ -64,5 +63,5 @@ alias flushdns='sudo dscacheutil -flushcache; sudo killall -HUP mDNSResponder'
 alias gm='gitmoji'
 
 # See what's listening on a given port
-alias whichport='sudo lsof -i -P | grep LISTEN | grep'
+# (implemented as function `whichport` in system/.functions)
 

--- a/system/.functions
+++ b/system/.functions
@@ -18,6 +18,16 @@ function killport() {
     echo "$pids" | xargs kill -9
 }
 
+# Show process(es) listening on a given port
+function whichport() {
+    if [[ -z "${1:-}" ]]; then
+        echo "Usage: whichport <port>"
+        return 1
+    fi
+
+    sudo lsof -nP -iTCP:"$1" -sTCP:LISTEN
+}
+
 # Create a new directory and enter it
 function mkd() {
     mkdir -p "$@" && cd "$_";


### PR DESCRIPTION
## Summary
Preflight minimalism pass before new-machine setup, per requested changes.

## Changes included
- Removed `brew "docker"` formula (keeping `docker-desktop` cask as the Docker path).
- Kept `cdl` alias (explicitly requested).
- Removed `alias -- -="cd -"`.
- Replaced `whichport` alias with a proper `whichport()` function in `system/.functions`:
  - usage: `whichport <port>`
  - uses `sudo lsof -nP -iTCP:<port> -sTCP:LISTEN`
- Added a short Brewfile note marking newer/optional casks as potentially higher-churn.

## Why
This keeps bootstrap setup leaner and slightly more robust while preserving your preferred shortcuts.
