### PR TITLE
feat: safer dotfiles sync workflow (no implicit pull/bootstrap)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Use `mise run ...` directly for project workflows:
 - `mise run ai-doctor` → AI CLI/tooling health check
 - `mise run lint-shell` / `mise run fmt-shell` / `mise run fmt-check`
 - `mise run precommit-install` / `mise run precommit-run`
+- `dsync` → safe dotfiles update preview (fetch/status + next commands)
 
 ## Structure
 

--- a/system/.functions
+++ b/system/.functions
@@ -33,12 +33,35 @@ function mkd() {
     mkdir -p "$@" && cd "$_";
 }
 
-# Reload dotfiles
-function reload-dotfiles() {
-    if [ -d "$HOME/dotfiles" ]; then
-        (cd "$HOME/dotfiles" && git pull origin master && ./bootstrap.sh)
-        source "$HOME/.zshrc"
+# Sync dotfiles safely (fetch + status + optional update)
+function dotfiles-sync() {
+    local repo="$HOME/dotfiles"
+
+    if [[ ! -d "$repo/.git" ]]; then
+        echo "Dotfiles repo not found at $repo"
+        return 1
     fi
+
+    (
+      cd "$repo" || exit 1
+      git fetch origin master --prune
+      echo "--- dotfiles status ---"
+      git status -sb
+      echo ""
+      echo "Recent upstream commits:"
+      git log --oneline --decorate HEAD..origin/master | head -20
+      echo ""
+      echo "Run these when ready:"
+      echo "  cd ~/dotfiles"
+      echo "  git pull --ff-only origin master"
+      echo "  ./bootstrap.sh"
+    )
+}
+
+# Reload shell only (no git/network side effects)
+function reload-dotfiles() {
+    source "$HOME/.zshrc"
+    echo "Reloaded ~/.zshrc"
 }
 
 # Determine size of a file or total size of a directory

--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -2,6 +2,7 @@
 
 # Navigation
 alias dtf="cd $DOTFILES"
+alias dsync="dotfiles-sync"
 
 # Reload shell
 alias reload="exec zsh -l"


### PR DESCRIPTION
## Summary
Next rollout pass: make dotfiles self-update behavior safer and more explicit.

## What changed
- Reworked `reload-dotfiles()` to do **reload only** (`source ~/.zshrc`) with no git/network/bootstrap side effects.
- Added `dotfiles-sync()` helper that:
  - fetches `origin/master`
  - shows concise repo status
  - shows incoming commits (`HEAD..origin/master`)
  - prints explicit next commands to pull/apply updates
- Added alias `dsync` for discoverability.
- Added README quick-command note for `dsync`.

## Why
This follows the "safe over implicit" direction:
- no hidden `git pull && ./bootstrap.sh` in a convenience function,
- still keeps update ergonomics fast,
- gives clear operator control before mutating the machine.
