### PR TITLE
feat: add lightweight git workflow helpers (groot + pr)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Use `mise run ...` directly for project workflows:
 - `mise run lint-shell` / `mise run fmt-shell` / `mise run fmt-check`
 - `mise run precommit-install` / `mise run precommit-run`
 - `dsync` → safe dotfiles update preview (fetch/status + next commands)
+- `groot` → jump to git repo root quickly
+- `pr` → open existing PR in browser or create one
 
 ## Structure
 

--- a/system/.functions
+++ b/system/.functions
@@ -64,6 +64,16 @@ function reload-dotfiles() {
     echo "Reloaded ~/.zshrc"
 }
 
+# Jump to the current git repository root
+function groot() {
+    cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)" || return 1
+}
+
+# Open existing PR in browser, or create one if missing
+function pr() {
+    gh pr view --web 2>/dev/null || gh pr create --web
+}
+
 # Determine size of a file or total size of a directory
 function fs() {
     if du -b /dev/null > /dev/null 2>&1; then


### PR DESCRIPTION
## Summary
Next rollout pass: add two small, high-frequency git workflow helpers inspired by the comparison repo.

## What changed
- Added `groot()` in `system/.functions`
  - jumps directly to current git repository root
- Added `pr()` in `system/.functions`
  - opens existing GitHub PR in browser (`gh pr view --web`)
  - falls back to create flow (`gh pr create --web`) when no PR exists

- Documented both commands in README quick commands.

## Why
These are lightweight but high-leverage daily helpers:
- less directory friction while working in nested paths,
- faster PR access/create loop.

No architectural changes and no behavior churn beyond these two commands.
