### PR TITLE
feat: add gitleaks secret-scanning guardrails

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,8 @@ repos:
     hooks:
       - id: shfmt
         args: ["-w", "-i", "2", "-ci"]
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.24.2
+    hooks:
+      - id: gitleaks
+        args: ["protect", "--staged", "--verbose"]

--- a/Brewfile
+++ b/Brewfile
@@ -22,6 +22,7 @@ brew "git-lfs"
 brew "gh"
 brew "commitizen"
 brew "pre-commit"       # Deterministic pre-commit checks
+brew "gitleaks"         # Secret scanning for commits/PRs
 brew "cloudflared"
 brew "gitmoji"
 brew "go"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Use `mise run ...` directly for project workflows:
 - `mise run ai-doctor` → AI CLI/tooling health check
 - `mise run lint-shell` / `mise run fmt-shell` / `mise run fmt-check`
 - `mise run precommit-install` / `mise run precommit-run`
+- `mise run secrets-scan` → run explicit repo secret scan
 - `dsync` → safe dotfiles update preview (fetch/status + next commands)
 - `groot` → jump to git repo root quickly
 - `pr` → open existing PR in browser or create one
@@ -52,7 +53,7 @@ The repository is organized into **topics**, making it easy to modularize your c
 - **Auto-update**: Automatically checks for updates to your dotfiles once a day.
 - **Mise integration**: Configured global settings + project tool/tasks for reproducible shell workflows.
 - **AI workflow diagnostics**: One-command checks for toolchain health and bootstrap verification.
-- **Deterministic guardrails**: Optional pre-commit hooks for shell lint/format and basic hygiene checks.
+- **Deterministic guardrails**: Optional pre-commit hooks for shell lint/format, merge hygiene, and secret scanning.
 - **Advanced Git**: Includes `gh-dash` and powerful log visualization.
 - **Ghostty terminal**: GPU-accelerated terminal with Catppuccin theme, Fira Code font, and custom keybindings — fully configured as dotfiles.
 - **Zed editor**: Primary editor with Catppuccin theme, Fira Code font, Prettier formatting, and custom keybindings — all managed as dotfiles.
@@ -179,6 +180,7 @@ Optional pre-commit config is included in `.pre-commit-config.yaml`:
 - trailing whitespace / EOF hygiene
 - `shellcheck`
 - `shfmt`
+- `gitleaks` secret scanning on staged changes
 
 Setup:
 ```bash

--- a/mise.toml
+++ b/mise.toml
@@ -7,6 +7,7 @@ min_version = { soft = "2025.1.0" }
 # Shell tooling used for dotfiles maintenance
 shellcheck = "latest"
 shfmt = "latest"
+gitleaks = "latest"
 
 [tasks.mise-install]
 description = "Install tools from mise.toml"
@@ -63,6 +64,10 @@ run = "pre-commit install"
 [tasks.precommit-run]
 description = "Run pre-commit hooks across all files"
 run = "pre-commit run --all-files"
+
+[tasks.secrets-scan]
+description = "Run gitleaks against repository"
+run = "gitleaks detect --source . --verbose"
 
 [tasks.doctor]
 description = "Run mise diagnostics"


### PR DESCRIPTION
## Summary
Next rollout pass: add lightweight secret-scanning guardrails so leaks are caught earlier.

## What changed
- Added `gitleaks` to `Brewfile`
- Added `gitleaks` hook to `.pre-commit-config.yaml` (staged-change protection)
- Added `gitleaks` to `mise.toml` managed tools
- Added `mise run secrets-scan` task for explicit full-repo scans
- Updated README docs for pre-commit + quick commands

## Why
This keeps your workflow lean but adds high-value safety:
- catches accidental key/token commits before they land,
- aligns with your existing pre-commit + verification setup,
- no architecture churn.
