### PR TITLE
feat: add pr-ready workflow helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Use `mise run ...` directly for project workflows:
 - `mise run lint-shell` / `mise run fmt-shell` / `mise run fmt-check`
 - `mise run precommit-install` / `mise run precommit-run`
 - `mise run secrets-scan` → run explicit repo secret scan
+- `mise run pr-ready` / `prready` → run checks and print PR body scaffold
 - `dsync` → safe dotfiles update preview (fetch/status + next commands)
 - `groot` → jump to git repo root quickly
 - `pr` → open existing PR in browser or create one
@@ -39,7 +40,7 @@ The repository is organized into **topics**, making it easy to modularize your c
 - `mise/`: Mise global config (symlinked to `~/.config/mise/`).
 - `codex/`: Codex CLI configuration (symlinked to `~/.codex/`).
 - `claude/`: Claude Code settings (symlinked to `~/.claude/`).
-- `scripts/`: Repository automation scripts (`doctor-ai`, `bootstrap-verify`).
+- `scripts/`: Repository automation scripts (`doctor-ai`, `bootstrap-verify`, `pr-ready`).
 - `zsh/`: Zsh configuration, plugins, and modular initialization.
 - `AGENTS.md`: Agent operating guidance for this repository.
 

--- a/mise.toml
+++ b/mise.toml
@@ -65,6 +65,10 @@ run = "pre-commit install"
 description = "Run pre-commit hooks across all files"
 run = "pre-commit run --all-files"
 
+[tasks.pr-ready]
+description = "Run checks and print a PR body scaffold"
+run = "./scripts/pr-ready.sh"
+
 [tasks.secrets-scan]
 description = "Run gitleaks against repository"
 run = "gitleaks detect --source . --verbose"

--- a/scripts/pr-ready.sh
+++ b/scripts/pr-ready.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "Run this inside a git repository."
+  exit 1
+fi
+
+base="${1:-master}"
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+echo "== PR Ready =="
+echo "Base:   $base"
+echo "Branch: $branch"
+echo
+
+echo "Running: mise run check"
+if command -v mise >/dev/null 2>&1; then
+  mise run check
+else
+  echo "⚠️  mise not found; skipping automated checks"
+fi
+
+echo
+echo "Suggested PR body scaffold"
+echo "-------------------------"
+echo "## Summary"
+git diff --name-only "$base...$branch" | sed 's/^/- /'
+echo
+echo "## Why"
+echo "- "
+echo
+echo "## Validation"
+echo "- [ ] mise run check"
+echo "- [ ] manual smoke test"

--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -26,4 +26,5 @@ alias msi="mise install"
 alias msu="mise upgrade"
 alias msr="mise run"
 alias msd="mise doctor"
+alias prready="mise run pr-ready"
 


### PR DESCRIPTION
## Summary
Next rollout pass: add a lightweight `pr-ready` workflow to speed up clean PR prep.

## What changed
- Added `scripts/pr-ready.sh`
  - validates repo context
  - runs `mise run check` (when available)
  - prints a reusable PR body scaffold based on changed files
- Added `mise` task:
  - `mise run pr-ready`
- Added shell shortcut:
  - `prready` → `mise run pr-ready`
- Updated README quick commands + script list.

## Why
This gives a fast, repeatable pre-PR flow with almost no new complexity:
- one command to run checks,
- one output scaffold to reduce PR-writing friction,
- stays consistent with existing `mise` workflow.
