### PR TITLE
feat: add tmux workflow tuned for Catppuccin + Claude

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -20,6 +20,7 @@ brew "gnupg"
 brew "git"
 brew "git-lfs"
 brew "gh"
+brew "tmux"
 brew "commitizen"
 brew "pre-commit"       # Deterministic pre-commit checks
 brew "gitleaks"         # Secret scanning for commits/PRs

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The repository is organized into **topics**, making it easy to modularize your c
 - `macos/`: macOS system defaults and UI/UX settings.
 - `system/`: Global environment variables, paths, and generic aliases.
 - `vim/`: Vim configuration.
+- `tmux/`: tmux configuration (symlinked to `~/.tmux.conf`).
 - `ghostty/`: Ghostty terminal configuration (symlinked to `~/.config/ghostty/`).
 - `zed/`: Zed editor settings and keybindings (symlinked to `~/.config/zed/`).
 - `mise/`: Mise global config (symlinked to `~/.config/mise/`).
@@ -50,6 +51,7 @@ The repository is organized into **topics**, making it easy to modularize your c
 - **Lean networking toolkit**: Modern DNS/HTTP/traffic inspection helpers (`doggo`, `mtr`, `iperf3`, `tcpdump`, `netcat`).
 - **FZF workflows**: Fast file/dir navigation, branch switching, ripgrep jump-to-file, and process kill helpers.
 - **Zsh Power-ups**: Syntax highlighting/autosuggestions plus faster completion startup and improved history behavior.
+- **tmux workflow**: Catppuccin-styled tmux with AI-friendly pane/window ergonomics and Claude quiet-window notifications.
 - **Auto-update**: Automatically checks for updates to your dotfiles once a day.
 - **Mise integration**: Configured global settings + project tool/tasks for reproducible shell workflows.
 - **AI workflow diagnostics**: One-command checks for toolchain health and bootstrap verification.
@@ -94,6 +96,32 @@ The repository is organized into **topics**, making it easy to modularize your c
 | `cmd+0` | Reset font size |
 
 > **Note:** `theme/iterm2-catppuccin.json` is preserved in the repo for historical reference but is no longer used.
+
+## tmux Workflow
+
+`tmux` is configured for a keyboard-first, AI-session-friendly terminal workflow.
+
+| File | Destination | Purpose |
+|------|-------------|---------|
+| `tmux/.tmux.conf` | `~/.tmux.conf` | Session/window/pane behavior + statusline |
+
+**Key choices:**
+- Prefix: `Ctrl+a`
+- Split panes in current working directory
+- Vim-style pane movement (`h/j/k/l`)
+- Fast pane resizing (`Shift+Arrow`)
+- Catppuccin-inspired statusline and borders
+- Copy mode with vim keys
+
+**Claude Teams fit:**
+- Includes a quiet-window notification hook (`alert-silence`) for windows using `monitor-silence`.
+- Useful pattern per Claude window:
+  - `tmux setw monitor-silence 15`
+
+**tmux aliases:**
+- `tl` → list sessions
+- `ta <name>` → attach session
+- `tn <name>` → create new named session
 
 ## Networking Workflow
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -41,6 +41,9 @@ ln -sf "$DOTFILES_ROOT/system/.curlrc" "$HOME/.curlrc"
 # Vim
 ln -sf "$DOTFILES_ROOT/vim/.vimrc" "$HOME/.vimrc"
 
+# tmux
+ln -sf "$DOTFILES_ROOT/tmux/.tmux.conf" "$HOME/.tmux.conf"
+
 # Zed
 mkdir -p "$HOME/.config/zed"
 ln -sf "$DOTFILES_ROOT/zed/settings.json" "$HOME/.config/zed/settings.json"

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -1,0 +1,62 @@
+# tmux config for ibarsi dotfiles
+# Optimized for terminal-heavy AI workflows (Claude/Codex) with Catppuccin-friendly colors.
+
+# Prefix: Ctrl+a (muscle-memory friendly)
+unbind C-b
+set -g prefix C-a
+bind C-a send-prefix
+
+# Base behavior
+set -g default-terminal "tmux-256color"
+set -ag terminal-overrides ",xterm-256color:RGB"
+set -g history-limit 100000
+set -g display-time 3000
+set -g status-interval 5
+set -g focus-events on
+set -sg escape-time 0
+set -g mouse on
+
+# Keep pane/window cwd inheritance for smoother project workflows
+bind c new-window -c "#{pane_current_path}"
+bind '|' split-window -h -c "#{pane_current_path}"
+bind '-' split-window -v -c "#{pane_current_path}"
+unbind '"'
+unbind '%'
+
+# Vim-style pane movement
+bind h select-pane -L
+bind j select-pane -D
+bind k select-pane -U
+bind l select-pane -R
+
+# Resize panes quickly
+bind -r S-Left resize-pane -L 5
+bind -r S-Right resize-pane -R 5
+bind -r S-Up resize-pane -U 5
+bind -r S-Down resize-pane -D 5
+
+# Session/window helpers
+bind r source-file ~/.tmux.conf \; display-message "tmux reloaded"
+bind C-f command-prompt -p "find-window" "find-window '%%'"
+bind C-k confirm-before -p "Kill session #S? (y/n)" kill-session
+
+# Copy mode (vim)
+set -g mode-keys vi
+bind Enter copy-mode
+bind -T copy-mode-vi v send -X begin-selection
+bind -T copy-mode-vi y send -X copy-selection-and-cancel
+bind -T copy-mode-vi Escape send -X cancel
+
+# Catppuccin-inspired status line
+set -g status-position bottom
+set -g status-style "bg=#1e1e2e,fg=#cdd6f4"
+set -g status-left " #[fg=#cba6f7,bold]#S #[default]"
+set -g status-right "#[fg=#6c7086]%Y-%m-%d #[fg=#89b4fa]%H:%M #[default]"
+set -g window-status-format " #[fg=#6c7086]#I:#W #[default]"
+set -g window-status-current-format " #[fg=#a6e3a1,bold]#I:#W #[default]"
+set -g pane-border-style "fg=#45475a"
+set -g pane-active-border-style "fg=#89b4fa"
+
+# Claude-oriented signal: if a monitored window goes quiet, notify on macOS.
+# Enable per-window when useful: tmux setw monitor-silence 15
+set-hook -g alert-silence "run-shell 'if command -v osascript >/dev/null 2>&1; then osascript -e \"display notification \\\"Claude window quiet (likely waiting for input)\\\" with title \\\"tmux: #{session_name}\\\"\"; fi'"

--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -27,3 +27,8 @@ alias msu="mise upgrade"
 alias msr="mise run"
 alias msd="mise doctor"
 
+# tmux
+alias tl="tmux ls"
+alias ta="tmux attach -t"
+alias tn="tmux new -s"
+


### PR DESCRIPTION
## Summary
Adds a tmux setup adapted from the comparison repo, optimized for your current Catppuccin + AI workflow.

## What changed
- Added `tmux/.tmux.conf` with:
  - `Ctrl+a` prefix
  - split panes inheriting current cwd
  - vim-style pane navigation (`h/j/k/l`)
  - quick pane resize with `Shift+Arrow`
  - Catppuccin-inspired statusline + pane colors
  - vim copy-mode bindings
  - optional quiet-window hook for Claude workflows (`alert-silence`)

- Added `brew "tmux"` to `Brewfile`
- Added bootstrap symlink:
  - `tmux/.tmux.conf` → `~/.tmux.conf`
- Added tmux shell aliases in `zsh/aliases.zsh`:
  - `tl`, `ta`, `tn`
- Added README `tmux Workflow` section + usage notes

## Claude Teams fit
The tmux config includes a quiet-window notification hook, and is designed to pair well with per-window monitor-silence:

```bash
tmux setw monitor-silence 15
```

This gives a non-intrusive signal when a Claude pane likely finished and is waiting for input.
