### PR TITLE
macos: map Caps Lock to Control and prevent LED toggle

### DIFF
--- a/macos/.macos
+++ b/macos/.macos
@@ -100,6 +100,17 @@ defaults write NSGlobalDomain ApplePressAndHoldEnabled -bool false
 # Set a blazingly fast keyboard repeat rate
 defaults write NSGlobalDomain KeyRepeat -int 1
 
+# Remap Caps Lock to Control globally.
+# This removes Caps Lock toggle behavior, so the Caps Lock LED no longer flips on/off when the key is pressed.
+hidutil property --set '{
+  "UserKeyMapping": [
+    {
+      "HIDKeyboardModifierMappingSrc": 0x700000039,
+      "HIDKeyboardModifierMappingDst": 0x7000000E0
+    }
+  ]
+}'
+
 ###############################################################################
 # Screen                                                                      #
 ###############################################################################


### PR DESCRIPTION
## Summary
- remap Caps Lock to Left Control using `hidutil` in `macos/.macos`
- remove Caps Lock toggle behavior so pressing the key no longer flips the Caps Lock LED

## Validation
- [x] `bash -n macos/.macos`

## Risk / Rollout Notes
- risk level: low
- applies when running the macOS setup script
- no migrations required
